### PR TITLE
Always check for aliases when deriving data types

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDataTypeSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDataTypeSpec.java
@@ -230,7 +230,11 @@ public class SqlDataTypeSpec extends SqlNode {
    */
   public RelDataType deriveType(SqlValidator validator, boolean nullable) {
     RelDataType type;
-    type = typeNameSpec.deriveType(validator);
+    // check if the type name is being used as an alias before calling `deriveType`
+    type = validator.getCatalogReader().getNamedType(typeNameSpec.getTypeName());
+    if (type == null) {
+      type = typeNameSpec.deriveType(validator);
+    }
 
     // Fix-up the nullability, default is false.
     final RelDataTypeFactory typeFactory = validator.getTypeFactory();

--- a/core/src/test/java/org/apache/calcite/test/UdtTest.java
+++ b/core/src/test/java/org/apache/calcite/test/UdtTest.java
@@ -29,6 +29,10 @@ class UdtTest {
         + "     {\n"
         + "       name: 'foo',\n"
         + "       type: 'BIGINT'\n"
+        + "     },\n"
+        + "     {\n"
+        + "       name: 'TIMESTAMP',\n"
+        + "       type: 'TIMESTAMP_WITH_LOCAL_TIME_ZONE'\n"
         + "     }"
         + "   ],\n"
         + "   schemas: [\n"
@@ -70,6 +74,13 @@ class UdtTest {
         + "from (VALUES ROW(1, 'SameName')) AS \"t\" (\"id\", \"desc\")";
     withUdt().query(sql).returns("LD=1\n");
   }
+
+  @Test void testAliasOnBasicType() {
+    final String sql = "select CAST(\"date\" AS TIMESTAMP) as ts "
+        + "from (VALUES ROW(DATE '2020-12-25', 'SameName')) AS \"t\" (\"date\", \"desc\")";
+    withUdt().query(sql).typeIs("[TS TIMESTAMP_WITH_LOCAL_TIME_ZONE NOT NULL]");
+  }
+
 
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-3045">[CALCITE-3045]

--- a/core/src/test/java/org/apache/calcite/util/SourceTest.java
+++ b/core/src/test/java/org/apache/calcite/util/SourceTest.java
@@ -30,10 +30,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.PrintWriter;
 import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -158,16 +157,16 @@ class SourceTest {
     // If the file is located in a JAR, we cannot write the file in place
     // so we add it to the /tmp directory
     // the expected output is /tmp/[jarname]/[path-to-file-in-jar/filename]_actual.json
-    logFilePath = refFilePath.replaceAll(
+    logFilePath = refFilePath.replace(
             ".*\\/(.*)\\.jar\\!(.*)\\.json",
             "/tmp/$1$2_actual.json");
     final File logFile = new File(logFilePath);
     assertThat(refFile, not(is(logFile.getAbsolutePath())));
     boolean b = logFile.getParentFile().mkdirs();
     Util.discard(b);
-    try (FileWriter fw = new FileWriter(logFile);
-         PrintWriter pw = new PrintWriter(fw)) {
-      pw.println("hello, world!");
+    try  {
+      FileOutputStream fw = new FileOutputStream(logFilePath);
+      fw.write("hello, world!\n".getBytes(StandardCharsets.UTF_8));
     } catch (IOException e) {
       throw Util.throwAsRuntime(e);
     }

--- a/testkit/src/main/java/org/apache/calcite/test/DiffRepository.java
+++ b/testkit/src/main/java/org/apache/calcite/test/DiffRepository.java
@@ -23,13 +23,13 @@ import org.apache.calcite.util.Sources;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.XmlOutput;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
-
-import org.apache.commons.lang3.StringUtils;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.Assertions;


### PR DESCRIPTION
Addresses missed case from https://github.com/looker-open-source/calcite/commit/6e40c7dcf5aa8aeb21a541755f452c74ebeee7cc where an aliased type uses the same name as an existing [basic SQL type](https://github.com/apache/calcite/blob/ae228f64347cc7620d28eff04f5869583c6bf9d5/core/src/main/java/org/apache/calcite/sql/SqlBasicTypeNameSpec.java#L32-L72).

Types defined in a schema now take precedence over basic types.