### PR TITLE
Override JDBC type for MEASURE columns

### DIFF
--- a/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/CalciteMetaImpl.java
@@ -78,6 +78,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 import static java.util.Objects.requireNonNull;
@@ -457,12 +458,20 @@ public class CalciteMetaImpl extends MetaImpl {
                   instanceof RelDataTypeFactoryImpl.JavaType)
                   ? field.getType().getPrecision()
                   : -1;
+          // MEASURE is a special case. We want to surface the type returned
+          // after aggregation rather than its default java.sql.Type of `OTHER(1111)`
+          final int jdbcOrdinal =
+              Optional
+                  .ofNullable(field.getType().getMeasureElementType())
+                  .map(RelDataType::getSqlTypeName)
+                  .map(SqlTypeName::getJdbcOrdinal)
+                  .orElse(field.getType().getSqlTypeName().getJdbcOrdinal());
           return new MetaColumn(
               table.tableCat,
               table.tableSchem,
               table.tableName,
               field.getName(),
-              field.getType().getSqlTypeName().getJdbcOrdinal(),
+              jdbcOrdinal,
               field.getType().getFullTypeString(),
               precision,
               field.getType().getSqlTypeName().allowsScale()

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataType.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataType.java
@@ -140,6 +140,15 @@ public interface RelDataType {
   @Nullable RelDataType getValueType();
 
   /**
+   * Gets the element type if this type is a measure, otherwise null.
+   *
+   * @return canonical type descriptor for the value used in the measure
+   */
+  default @Nullable RelDataType getMeasureElementType() {
+    return null;
+  }
+
+  /**
    * Gets this type's character set, or null if this type cannot carry a
    * character set or has no character set defined.
    *

--- a/core/src/main/java/org/apache/calcite/sql/type/MeasureSqlType.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/MeasureSqlType.java
@@ -27,10 +27,16 @@ import com.google.common.collect.ImmutableList;
  * into an expression before use.
  */
 public class MeasureSqlType extends ApplySqlType {
+  private final RelDataType elementType;
   /** Private constructor. */
   private MeasureSqlType(RelDataType elementType, boolean isNullable) {
     super(SqlTypeName.MEASURE, isNullable, ImmutableList.of(elementType));
+    this.elementType = elementType;
     computeDigest();
+  }
+
+  @Override public RelDataType getMeasureElementType() {
+    return elementType;
   }
 
   /** Creates a MeasureSqlType. */

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -8608,8 +8608,8 @@ public class SqlOperatorTest {
     f.checkScalar("FORMAT_DATE('%x', DATE '2008-12-25')",
         "12/25/08",
         "VARCHAR(2000) NOT NULL");
-    f.checkScalar("FORMAT_DATE('The date is: %x', DATE '2008-12-25')",
-        "The date is: 12/25/08",
+    f.checkScalar("FORMAT_DATE('The date is: %x', DATE '2008-12-01')",
+        "The date is: 12/01/08",
         "VARCHAR(2000) NOT NULL");
   }
 


### PR DESCRIPTION
To fulfill the updated spec:

> DATA_TYPE holds the SQL type code of the column (e.g. 16 (BOOLEAN) for Looker ‘yesno’ fields, 4 (INTEGER) for a measure column of type INTEGER, 93 (TIMESTAMP) for a column that of a type that BigQuery would call "DATETIME" or "TIMESTAMP"); TYPE_NAME holds the name of the type (e.g. "BOOLEAN" for Looker 'yesno' fields, > "MEASURE<INTEGER>" for a measure column of type INTEGER, "TIMESTAMP" for a column of a type that BigQuery would call "DATETIME" and ISO SQL would call "TIMESTAMP", "TIMESTAMP WITH LOCAL TIME ZONE" for a type that BigQuery would call "TIMESTAMP"); IS_GENERATEDCOLUMN is ‘YES’ for measures and ‘NO’ for dimensions.
