### PR TITLE
Use first datetime operand as DATE_TRUNC return type

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -857,11 +857,14 @@ public abstract class SqlLibraryOperators {
               SqlTypeFamily.ANY));
 
   /** The "DATE_TRUNC(date, timeUnit)" function (BigQuery);
-   * truncates a DATE value to the beginning of a timeUnit. */
+   * truncates a DATE value to the beginning of a timeUnit.
+   *
+   * TODO(CALCITE-5290): Add `DATE_TRUNC` function consistent with Postgres. Currently, Postgres
+   *                     style calls can be parsed but fail validation. */
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction DATE_TRUNC =
       SqlBasicFunction.create("DATE_TRUNC",
-          ReturnTypes.DATE_NULLABLE,
+          ReturnTypes.FIRST_DATETIME_ARG,
           OperandTypes.sequence("'DATE_TRUNC(<DATE>, <DATETIME_INTERVAL>)'",
               OperandTypes.DATE, OperandTypes.dateInterval()),
           SqlFunctionCategory.TIMEDATE)

--- a/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
@@ -276,6 +276,23 @@ public abstract class ReturnTypes {
       };
 
   /**
+   * Type-inference strategy that uses the first operand that is a member of
+   * {@link SqlTypeFamily#DATETIME} as the return type.
+   */
+  public static final SqlReturnTypeInference FIRST_DATETIME_ARG =
+      opBinding -> {
+        final int n = opBinding.getOperandCount();
+        RelDataType type1 = null;
+        for (int i = 0; i < n; i++) {
+          type1 = opBinding.getOperandType(i);
+          if (SqlTypeUtil.isDatetime(type1)) {
+            break;
+          }
+        }
+        return type1;
+      };
+
+  /**
    * Type-inference strategy whereby the result type of a call is a nullable
    * Boolean.
    */


### PR DESCRIPTION
Smallest change necessary for this not to break existing HT tests - part of upstream change covered in [CALCITE-5290](https://issues.apache.org/jira/browse/CALCITE-5290)