### PR TITLE
Revert "[CALCITE-5510] RelToSqlConverter should use ordinal for `ORDER BY` if the dialect allows"

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -617,13 +617,6 @@ public abstract class SqlImplementor {
         final String strValue = ((SqlNumericLiteral) node).toValue();
         return SqlLiteral.createCharString(strValue, node.getParserPosition());
       }
-      if (node instanceof SqlCall
-          && dialect.getConformance().isSortByOrdinal()) {
-        // If the field is expression and sort by ordinal is set in dialect,
-        // convert it to ordinal.
-        return SqlLiteral.createExactNumeric(
-            Integer.toString(ordinal + 1), SqlParserPos.ZERO);
-      }
       return node;
     }
 
@@ -1825,13 +1818,6 @@ public abstract class SqlImplementor {
         return true;
       }
 
-      if (rel instanceof Project
-          && clauses.contains(Clause.ORDER_BY)
-          && dialect.getConformance().isSortByOrdinal()) {
-        // Cannot merge a Project that contains sort by ordinal under it.
-        return hasSortByOrdinal();
-      }
-
       if (rel instanceof Aggregate) {
         final Aggregate agg = (Aggregate) rel;
         final boolean hasNestedAgg =
@@ -1849,30 +1835,6 @@ public abstract class SqlImplementor {
         }
       }
 
-      return false;
-    }
-
-    /**
-     * Return whether the current {@link SqlNode} in {@link Result} contains sort by column
-     * in ordinal format.
-     */
-    private boolean hasSortByOrdinal(@UnknownInitialization Result this) {
-      if (node instanceof SqlSelect) {
-        final SqlNodeList orderList = ((SqlSelect) node).getOrderList();
-        if (orderList == null) {
-          return false;
-        }
-        for (SqlNode sqlNode : orderList) {
-          if (!(sqlNode instanceof SqlBasicCall)) {
-            return false;
-          }
-          for (SqlNode operand : ((SqlBasicCall) sqlNode).getOperandList()) {
-            if (operand instanceof SqlNumericLiteral) {
-              return true;
-            }
-          }
-        }
-      }
       return false;
     }
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -61,7 +61,6 @@ import org.apache.calcite.sql.dialect.MssqlSqlDialect;
 import org.apache.calcite.sql.dialect.MysqlSqlDialect;
 import org.apache.calcite.sql.dialect.OracleSqlDialect;
 import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
-import org.apache.calcite.sql.dialect.PrestoSqlDialect;
 import org.apache.calcite.sql.fun.SqlLibrary;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParser;
@@ -605,7 +604,7 @@ class RelToSqlConverterTest {
         + "GROUP BY GROUPING SETS((\"EMPNO\", \"ENAME\", \"JOB\"),"
         + " (\"EMPNO\", \"ENAME\"), \"EMPNO\")\n"
         + "HAVING GROUPING(\"EMPNO\", \"ENAME\", \"JOB\") <> 0\n"
-        + "ORDER BY 4";
+        + "ORDER BY COUNT(*)";
     relFn(relFn).ok(expectedSql);
   }
 
@@ -768,17 +767,17 @@ class RelToSqlConverterTest {
     final String expected = "SELECT \"product_class_id\", COUNT(*) AS \"C\"\n"
         + "FROM \"foodmart\".\"product\"\n"
         + "GROUP BY ROLLUP(\"product_class_id\")\n"
-        + "ORDER BY \"product_class_id\", 2";
+        + "ORDER BY \"product_class_id\", COUNT(*)";
     final String expectedMysql = "SELECT `product_class_id`, COUNT(*) AS `C`\n"
         + "FROM `foodmart`.`product`\n"
         + "GROUP BY `product_class_id` WITH ROLLUP\n"
         + "ORDER BY `product_class_id` IS NULL, `product_class_id`,"
-        + " COUNT(*) IS NULL, 2";
+        + " COUNT(*) IS NULL, COUNT(*)";
     final String expectedPresto = "SELECT \"product_class_id\", COUNT(*) AS \"C\"\n"
         + "FROM \"foodmart\".\"product\"\n"
         + "GROUP BY ROLLUP(\"product_class_id\")\n"
         + "ORDER BY \"product_class_id\" IS NULL, \"product_class_id\", "
-        + "COUNT(*) IS NULL, 2";
+        + "COUNT(*) IS NULL, COUNT(*)";
     sql(query)
         .ok(expected)
         .withMysql().ok(expectedMysql)
@@ -818,14 +817,14 @@ class RelToSqlConverterTest {
         + " COUNT(*) AS \"C\"\n"
         + "FROM \"foodmart\".\"product\"\n"
         + "GROUP BY ROLLUP(\"product_class_id\", \"brand_name\")\n"
-        + "ORDER BY \"product_class_id\", \"brand_name\", 3";
+        + "ORDER BY \"product_class_id\", \"brand_name\", COUNT(*)";
     final String expectedMysql = "SELECT `product_class_id`, `brand_name`,"
         + " COUNT(*) AS `C`\n"
         + "FROM `foodmart`.`product`\n"
         + "GROUP BY `product_class_id`, `brand_name` WITH ROLLUP\n"
         + "ORDER BY `product_class_id` IS NULL, `product_class_id`,"
         + " `brand_name` IS NULL, `brand_name`,"
-        + " COUNT(*) IS NULL, 3";
+        + " COUNT(*) IS NULL, COUNT(*)";
     sql(query)
         .ok(expected)
         .withMysql().ok(expectedMysql);
@@ -1767,35 +1766,6 @@ class RelToSqlConverterTest {
     // Default dialect keep numeric constant keys in the over of order-by.
     sql(query).ok("SELECT ROW_NUMBER() OVER (ORDER BY 1)\n"
         + "FROM \"foodmart\".\"employee\"");
-  }
-
-  /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-5510">[CALCITE-5510]
-   * RelToSqlConverter don't support sort by ordinal when sort by column is an expression</a>.
-   */
-  @Test void testOrderByOrdinalWithExpression() {
-    final String query = "select \"product_id\", count(*) as \"c\"\n"
-        + "from \"product\"\n"
-        + "group by \"product_id\"\n"
-        + "order by 2";
-    final String ordinalExpected = "SELECT \"product_id\", COUNT(*) AS \"c\"\n"
-        + "FROM \"foodmart\".\"product\"\n"
-        + "GROUP BY \"product_id\"\n"
-        + "ORDER BY 2";
-    final String nonOrdinalExpected = "SELECT product_id, COUNT(*) AS c\n"
-        + "FROM foodmart.product\n"
-        + "GROUP BY product_id\n"
-        + "ORDER BY COUNT(*)";
-    final String prestoExpected = "SELECT \"product_id\", COUNT(*) AS \"c\"\n"
-        + "FROM \"foodmart\".\"product\"\n"
-        + "GROUP BY \"product_id\"\n"
-        + "ORDER BY COUNT(*) IS NULL, 2";
-    sql(query)
-        .ok(ordinalExpected)
-        .dialect(nonOrdinalDialect())
-        .ok(nonOrdinalExpected)
-        .dialect(PrestoSqlDialect.DEFAULT)
-        .ok(prestoExpected);
   }
 
   /** Test case for
@@ -6779,7 +6749,7 @@ class RelToSqlConverterTest {
         + "FROM SCOTT.EMP\n"
         + "GROUP BY DEPTNO\n"
         + "HAVING COUNT(DISTINCT EMPNO) > 0\n"
-        + "ORDER BY COUNT(DISTINCT EMPNO) IS NULL DESC, 2 DESC";
+        + "ORDER BY COUNT(DISTINCT EMPNO) IS NULL DESC, COUNT(DISTINCT EMPNO) DESC";
 
     // Convert rel node to SQL with BigQuery dialect,
     // in which "isHavingAlias" is true.

--- a/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
+++ b/piglet/src/test/java/org/apache/calcite/test/PigRelOpTest.java
@@ -1362,7 +1362,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "BIGINT) AS $f1, CAST(SUM(SAL) AS DECIMAL(19, 0)) AS salSum\n"
         + "FROM scott.EMP\n"
         + "GROUP BY DEPTNO, MGR, HIREDATE\n"
-        + "ORDER BY 3";
+        + "ORDER BY CAST(SUM(SAL) AS DECIMAL(19, 0))";
     pig(script).assertResult(is(result))
         .assertSql(is(sql));
   }
@@ -1480,7 +1480,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "(19, 0)) AS salAvg\n"
         + "FROM scott.EMP\n"
         + "GROUP BY DEPTNO, MGR, HIREDATE\n"
-        + "ORDER BY 3";
+        + "ORDER BY CAST(SUM(SAL) AS DECIMAL(19, 0))";
     pig(script).assertRel(hasTree(plan))
         .assertOptimizedRel(hasTree(optimizedPlan))
         .assertResult(is(result))
@@ -1501,7 +1501,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "AS A\n"
         + "FROM scott.EMP\n"
         + "GROUP BY DEPTNO, MGR, HIREDATE\n"
-        + "ORDER BY 3";
+        + "ORDER BY CAST(SUM(SAL) AS DECIMAL(19, 0))";
     pig(script2).assertSql(is(sql2));
 
     final String script3 = ""
@@ -1551,7 +1551,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "COLLECT(COMM) AS comArray, CAST(SUM(SAL) AS DECIMAL(19, 0)) AS salSum\n"
         + "FROM scott.EMP\n"
         + "GROUP BY DEPTNO, MGR, HIREDATE\n"
-        + "ORDER BY 7";
+        + "ORDER BY CAST(SUM(SAL) AS DECIMAL(19, 0))";
     pig(script).assertRel(hasTree(plan))
         .assertOptimizedRel(hasTree(optimizedPlan))
         .assertSql(is(sql));
@@ -1610,7 +1610,7 @@ class PigRelOpTest extends PigRelTestBase {
         + "    FROM scott.DEPT\n"
         + "    WHERE DEPTNO >= 20\n"
         + "    GROUP BY CAST(DEPTNO AS INTEGER)) AS t7 ON t4.DEPTNO = t7.DEPTNO\n"
-        + "ORDER BY 1";
+        + "ORDER BY CASE WHEN t4.DEPTNO IS NOT NULL THEN t4.DEPTNO ELSE t7.DEPTNO END";
     pig(script).assertRel(hasTree(plan))
         .assertResult(is(result))
         .assertSql(is(sql));


### PR DESCRIPTION
This reverts commit a990ecc4aee797f6d5a58cebcd18de38ae7a66cc.

This change was causing failures for subtotals and pivots. We can revisit to reenable if necessary.