### PR TITLE
Revert "[CALCITE-5518] RelToSql converter generates invalid order of ROLLUP fields"

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -618,13 +618,8 @@ public class RelToSqlConverter extends SqlImplementor
       // a singleton CUBE and ROLLUP are the same but we prefer ROLLUP;
       // fall through
     case ROLLUP:
-      final List<Integer> rollupBits = Aggregate.Group.getRollup(aggregate.groupSets);
-      final List<SqlNode> rollupKeys = rollupBits
-          .stream()
-          .map(bit -> builder.context.field(bit))
-          .collect(Collectors.toList());
       return ImmutableList.of(
-          SqlStdOperatorTable.ROLLUP.createCall(SqlParserPos.ZERO, rollupKeys));
+          SqlStdOperatorTable.ROLLUP.createCall(SqlParserPos.ZERO, groupKeys));
     default:
     case OTHER:
       // Make sure that the group sets contains all bits.

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -684,34 +684,6 @@ class RelToSqlConverterTest {
         .withMysql().ok(expectedMysql);
   }
 
-  /** Test case for
-   * <a href="https://issues.apache.org/jira/browse/CALCITE-5518">[CALCITE-5518]
-   * RelToSql converter generates invalid order of ROLLUP fields</a>.
-   */
-  @Test void testGroupingSetsRollupNonNaturalOrder() {
-    final String query1 = "select \"product_class_id\", \"brand_name\"\n"
-        + "from \"product\"\n"
-        + "group by GROUPING SETS ((\"product_class_id\", \"brand_name\"),"
-        + " (\"brand_name\"), ())\n";
-    final String expected1 = "SELECT \"product_class_id\", \"brand_name\"\n"
-        + "FROM \"foodmart\".\"product\"\n"
-        + "GROUP BY ROLLUP(\"brand_name\", \"product_class_id\")";
-    sql(query1)
-        .withPostgresql().ok(expected1);
-
-    final String query2 = "select \"product_class_id\", \"brand_name\", \"product_id\"\n"
-        + "from \"product\"\n"
-        + "group by GROUPING SETS ("
-        + " (\"product_class_id\", \"brand_name\", \"product_id\"),"
-        + " (\"product_class_id\", \"brand_name\"),"
-        + " (\"brand_name\"), ())\n";
-    final String expected2 = "SELECT \"product_class_id\", \"brand_name\", \"product_id\"\n"
-        + "FROM \"foodmart\".\"product\"\n"
-        + "GROUP BY ROLLUP(\"brand_name\", \"product_class_id\", \"product_id\")";
-    sql(query2)
-        .withPostgresql().ok(expected2);
-  }
-
   /** Tests a query with GROUP BY and a sub-query which is also with GROUP BY.
    * If we flatten sub-queries, the number of rows going into AVG becomes
    * incorrect. */


### PR DESCRIPTION
This reverts commit 90599a6e9b0143eb3d9175af7b5ff374e1b95252.

There's a lot of custom work in our subtotal logic and expected results. Would rather just miss out on this change what we have a risk a P0.