### PR TITLE
[b/328439985] Convert negative SQRT operands to NULL in dialect.tdd

### DIFF
--- a/connector/tableau/looker-jdbc/dialect.tdd
+++ b/connector/tableau/looker-jdbc/dialect.tdd
@@ -239,7 +239,8 @@
       <argument type='real' />
     </function>
     <function group='numeric' name='SQRT' return-type='real'>
-      <formula>SQRT(%1)</formula>
+      <!-- BQ throws an error on negative numbers, instead we want NULL. -->
+      <formula>SQRT(IF(%1 < 0, NULL, %1))</formula>
       <argument type='real' />
     </function>
     <function group='numeric' name='SQUARE' return-type='real'>


### PR DESCRIPTION
BigQuery throws an error when trying to compute the square root of a negative number. To prevent this, we wrap the operand in an `IF` that converts the current row to null if it is negative. This seems to align with Tableau's expectations.