### PR TITLE
[b/328440720] Cast STRING to FLOAT64 before casting to INTEGER

### DIFF
--- a/connector/tableau/looker-jdbc/dialect.tdd
+++ b/connector/tableau/looker-jdbc/dialect.tdd
@@ -553,7 +553,11 @@
       <argument type='int' />
     </function>
     <function group='cast' name='INT' return-type='int'>
-      <formula>CAST((%1) AS INTEGER)</formula>
+      <!-- Casting directly to INTEGER errors if there's a decimal, so cast to FLOAT64 first.
+           Casting FLOAT64 to INTEGER returns the nearest integer so something like "19.8"
+           will becoming 20. The alternative is to add extra logic to ensure the whole part
+           remains the same, but this is more complicated (a.k.a. more error prone).  -->
+      <formula>CAST(CAST((%1) AS FLOAT64) AS INTEGER)</formula>
       <argument type='str' />
     </function>
     <function group='cast' name='INT' return-type='int'>


### PR DESCRIPTION
As the comment in dialect.tdd details, to avoid errors with decimals. we cast strings to FLOAT64 before casting them to INTEGERs. As a result of this, the whole part of the number is not always preserved (it casts to the nearest integer). We decided to do this instead of adding an additional block to the SQL that preserves the whole part for simplicity's sake