### PR TITLE
[b/330547397] Adjust negative index handling for SPLIT

### DIFF
--- a/connector/tableau/looker-jdbc/dialect.tdd
+++ b/connector/tableau/looker-jdbc/dialect.tdd
@@ -1648,7 +1648,8 @@
     </date-function>
     <native-split-function>
       <formula part='left'>(SPLIT((%1), (%2))[SAFE_ORDINAL(%3)])</formula>
-      <formula part='right'>(ARRAY_REVERSE(SPLIT((%1), (%2)))[SAFE_ORDINAL(%3)])</formula>
+      <!-- For negative index, reverse array and use additive inverse of index. -->
+      <formula part='right'>(ARRAY_REVERSE(SPLIT((%1), (%2)))[SAFE_ORDINAL(%3 * -1)])</formula>
     </native-split-function>
   </function-map>
   <supported-aggregations>


### PR DESCRIPTION
If we receive a request like `SPLIT("a-b-c", "-", -2)`, we should return `b` since that is the second to last element of the resulting split ([a, b, c]). We can do this in BigQuery by reversing the array (using ARRAY_REVERSE) and then multiplying the index by -1. Previously, we correctly reversed the array, but we continued using the original negative index instead of its additive inverse. This change corrects that.