### PR TITLE
Set User Agent request param value in Tableau connector conn url string

### DIFF
--- a/connector/tableau/looker-jdbc/connectionBuilder.js
+++ b/connector/tableau/looker-jdbc/connectionBuilder.js
@@ -21,7 +21,7 @@
     var urlBuilder = "jdbc:looker:url=https://" +
         attr[connectionHelper.attributeServer] +
         ":" + attr[connectionHelper.attributePort] +
-	";userAgent=Tableau";
+	";userAgent=Tableau-Connector-"+attr["v-plugin-version"];
     return [urlBuilder];
 })
 

--- a/connector/tableau/looker-jdbc/connectionFields.xml
+++ b/connector/tableau/looker-jdbc/connectionFields.xml
@@ -49,4 +49,6 @@
     </conditions>
   </field>
 
+  <field name="v-plugin-version" label="Plugin Version" value-type="string" category="general" default-value="0.2.0" editable="false"/>
+
 </connection-fields>

--- a/connector/tableau/looker-jdbc/connectionResolver.tdr
+++ b/connector/tableau/looker-jdbc/connectionResolver.tdr
@@ -30,6 +30,7 @@
           <attr>authentication</attr>
           <attr>username</attr>
           <attr>password</attr>
+          <attr>v-plugin-version</attr>
         </attribute-list>
       </required-attributes>
     </connection-normalizer>


### PR DESCRIPTION
Fixes b/343254086 (refer for additional context and steps used below to look for api headers) 

Verified by testing the updated connector taco from a local tableau instance with the `experiment-tableau-bugbash` auxilia looker instance, nginx ingress logs shows the user agent populated correctly.

<img width="1060" alt="image" src="https://github.com/looker-open-source/calcite/assets/12583553/f0a6db2f-bc7a-4c40-86b1-cfa58d5f328a">